### PR TITLE
windowsで使用できない文字をファイル名に使わないようにする 

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -17,6 +17,9 @@ namespace Rapad
         private Point mousePoint;
         bool isForemost = true;
         List<string> tmpHtmlFileList = new List<string>();
+        
+        // windowsでファイル名に使用できない文字を置換するための正規表現
+        const string UNUSABLE_CHARS_PATTERN = @"[\\/:*?""<>|]";
 
         public Form1()
         {
@@ -146,8 +149,7 @@ namespace Rapad
                 string noSharpText = textBox1.Lines[0].ToString().Replace("# ", "");
 
                 // ファイル名に使用できない文字を削除
-                string unUsableChar = @"\\|\/|\:|\*|\?|""|<|>|\|";
-                string result = Regex.Replace(noSharpText, unUsableChar, "_");
+                string result = Regex.Replace(noSharpText, UNUSABLE_CHARS_PATTERN, "_");
 
                 fileName = result + ".md";
             }

--- a/Form1.cs
+++ b/Form1.cs
@@ -8,6 +8,7 @@ using Markdig;
 
 using System.Diagnostics;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 
 namespace Rapad
 {
@@ -143,7 +144,12 @@ namespace Rapad
             if (textBox1.Lines[0].ToString().StartsWith("# "))
             {
                 string noSharpText = textBox1.Lines[0].ToString().Replace("# ", "");
-                fileName = noSharpText + ".md";
+
+                // ファイル名に使用できない文字を削除
+                string unUsableChar = @"\\|\/|\:|\*|\?|""|<|>|\|";
+                string result = Regex.Replace(noSharpText, unUsableChar, "_");
+
+                fileName = result + ".md";
             }
             else
             {
@@ -151,7 +157,6 @@ namespace Rapad
             }
 
             afterPath = path.Replace("Rapad.exe", "history\\" + fileName);
-
 
             // ファイル作成部分
             FileInfo fileInfo = new FileInfo(afterPath);

--- a/Rapad.csproj
+++ b/Rapad.csproj
@@ -36,8 +36,8 @@
     <ApplicationIcon>Rapad.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Markdig, Version=0.36.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Markdig.0.36.2\lib\net462\Markdig.dll</HintPath>
+    <Reference Include="Markdig, Version=0.37.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Markdig.0.37.0\lib\net462\Markdig.dll</HintPath>
     </Reference>
     <Reference Include="Markdig.Wpf, Version=0.5.0.1, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\Markdig.Wpf.0.5.0.1\lib\net452\Markdig.Wpf.dll</HintPath>

--- a/packages.config
+++ b/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Markdig" version="0.36.2" targetFramework="net472" />
+  <package id="Markdig" version="0.37.0" targetFramework="net472" />
   <package id="Markdig.Wpf" version="0.5.0.1" targetFramework="net472" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
   <package id="System.Memory" version="4.5.5" targetFramework="net472" />


### PR DESCRIPTION
#35 


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
- New Feature: ファイル名生成ロジックを改善し、Windowsで使用できない文字を自動的に削除または置換します。
- Bug fix: 重複するファイル名が存在する場合に末尾に`_{数字}`を追加するように修正しました。
- Chore: Markdigライブラリのバージョンを0.36.0.0から0.37.0.0に更新しました。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->